### PR TITLE
Allow set NG to zero to disable entire casper processing.

### DIFF
--- a/maint/buildiface
+++ b/maint/buildiface
@@ -264,7 +264,7 @@ while (<INFILE>) {
             if (grep/MPI_Comm $/, $arglist[$x]) {
                 $comm_arg = $x;
 
-                print CFILE "${tab}if (x$comm_arg == MPI_COMM_WORLD)\n";
+                print CFILE "${tab}if (x$comm_arg == MPI_COMM_WORLD && !CSP_IS_DISABLED)\n";
                 print CFILE "${tab}${tab}x$comm_arg = CSP_COMM_USER_WORLD;\n"
             }
         }

--- a/src/common/include/csp.h
+++ b/src/common/include/csp.h
@@ -190,6 +190,7 @@ extern CSP_proc_t CSP_PROC;
 
 #define CSP_IS_USER (CSP_PROC.proc_type == CSP_PROC_USER)
 #define CSP_IS_GHOST (CSP_PROC.proc_type == CSP_PROC_GHOST)
+#define CSP_IS_DISABLED (CSP_ENV.num_g == 0)
 
 /* Initialize global information objects. */
 static inline void CSP_reset_proc(void)

--- a/src/user/comm/comm_create.c
+++ b/src/user/comm/comm_create.c
@@ -13,6 +13,10 @@ int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm * newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_create(comm, group, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_create_group.c
+++ b/src/user/comm/comm_create_group.c
@@ -13,6 +13,10 @@ int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm * ne
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_create_group(comm, group, tag, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_dup.c
+++ b/src/user/comm/comm_dup.c
@@ -12,6 +12,10 @@ int MPI_Comm_dup(MPI_Comm comm, MPI_Comm * newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_dup(comm, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_dup_with_info.c
+++ b/src/user/comm/comm_dup_with_info.c
@@ -12,6 +12,10 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_dup_with_info(comm, info, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_free.c
+++ b/src/user/comm/comm_free.c
@@ -12,6 +12,10 @@ int MPI_Comm_free(MPI_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_free(comm);
+
     /* User should not free COMM_WORLD, but we just let MPI to handle such error.
      * Even user makes such mistake, we do not free COMM_USER_WORLD. */
 

--- a/src/user/comm/comm_idup.c
+++ b/src/user/comm/comm_idup.c
@@ -12,6 +12,10 @@ int MPI_Comm_idup(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_idup(comm, newcomm, request);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_split.c
+++ b/src/user/comm/comm_split.c
@@ -13,6 +13,10 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm * newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_split(comm, color, key, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/comm_split_type.c
+++ b/src/user/comm/comm_split_type.c
@@ -13,6 +13,10 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_split_type(comm, split_type, key, info, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/intercomm_create.c
+++ b/src/user/comm/intercomm_create.c
@@ -13,6 +13,11 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Intercomm_create(local_comm, local_leader, peer_comm,
+                                     remote_leader, tag, newintercomm);
+
     if (local_comm == MPI_COMM_WORLD)
         local_comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/comm/intercomm_merge.c
+++ b/src/user/comm/intercomm_merge.c
@@ -12,6 +12,10 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm * newintracomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Intercomm_merge(intercomm, high, newintracomm);
+
     if (intercomm == MPI_COMM_WORLD)
         intercomm = CSP_COMM_USER_WORLD;
 

--- a/src/user/errhan/comm_call_errhandler.c
+++ b/src/user/errhan/comm_call_errhandler.c
@@ -12,6 +12,10 @@ int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode)
     int mpi_errno = MPI_SUCCESS;
     int errcode_val = errorcode;        /* to pass valid address */
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_call_errhandler(comm, errorcode);
+
     CSPU_ERRHAN_RESET_EXTOBJ();
     mpi_errno = CSPU_comm_call_errhandler(comm, &errcode_val);
     CSP_CHKMPIFAIL_JUMP(mpi_errno);

--- a/src/user/errhan/comm_create_errhandler.c
+++ b/src/user/errhan/comm_create_errhandler.c
@@ -14,6 +14,10 @@ int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function * comm_errhandler_fn
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_create_errhandler(comm_errhandler_fn, errhandler);
+
     CSP_CALLMPI(JUMP, PMPI_Comm_create_errhandler(comm_errhandler_fn, errhandler));
 
     /* Because no way to get the user function from handler, we store it into hash.

--- a/src/user/errhan/comm_get_errhandler.c
+++ b/src/user/errhan/comm_get_errhandler.c
@@ -13,6 +13,10 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler * errhandler)
     MPI_Errhandler cached_errhandler = MPI_ERRHANDLER_NULL;
     MPI_Comm_errhandler_function *cached_fnc = NULL;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return MPI_Comm_get_errhandler(comm, errhandler);
+
     /* The error handler in any communicator exposed to user should be wrapped,
      * and the original user error handler is in cached. */
     CSPU_comm_errhan_get(comm, &cached_errhandler, &cached_fnc);

--- a/src/user/errhan/comm_set_errhandler.c
+++ b/src/user/errhan/comm_set_errhandler.c
@@ -13,6 +13,10 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
     int mpi_errno = MPI_SUCCESS;
     MPI_Comm_errhandler_function *errhandler_fnc = NULL;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_set_errhandler(comm, errhandler);
+
     if (errhandler != MPI_ERRORS_ARE_FATAL && errhandler != MPI_ERRORS_RETURN) {
         /* Get cached user function on this handler */
         CSPU_errhan_get_fnc(errhandler, (void **) (&errhandler_fnc));

--- a/src/user/errhan/errhandler_free.c
+++ b/src/user/errhan/errhandler_free.c
@@ -13,6 +13,10 @@ int MPI_Errhandler_free(MPI_Errhandler * errhandler)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Errhandler_free(errhandler);
+
     /* Remove cached [error handler -> callback function] record, only free if found. */
     CSPU_errhan_remove_fnc(*errhandler);
 

--- a/src/user/errhan/win_call_errhandler.c
+++ b/src/user/errhan/win_call_errhandler.c
@@ -12,6 +12,10 @@ int MPI_Win_call_errhandler(MPI_Win win, int errorcode)
     int mpi_errno = MPI_SUCCESS;
     int errcode_val = errorcode;        /* to pass valid address */
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_call_errhandler(win, errorcode);
+
     CSPU_ERRHAN_RESET_EXTOBJ();
     mpi_errno = CSPU_win_call_errhandler(win, &errcode_val);
     CSP_CHKMPIFAIL_JUMP(mpi_errno);

--- a/src/user/errhan/win_create_errhandler.c
+++ b/src/user/errhan/win_create_errhandler.c
@@ -14,6 +14,10 @@ int MPI_Win_create_errhandler(MPI_Win_errhandler_function * win_errhandler_fn,
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_create_errhandler(win_errhandler_fn, errhandler);
+
     CSP_CALLMPI(JUMP, PMPI_Win_create_errhandler(win_errhandler_fn, errhandler));
 
     /* Because no way to get the user function from handler, we store it into hash.

--- a/src/user/errhan/win_get_errhandler.c
+++ b/src/user/errhan/win_get_errhandler.c
@@ -13,6 +13,10 @@ int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler * errhandler)
     MPI_Errhandler cached_errhandler = MPI_ERRHANDLER_NULL;
     MPI_Win_errhandler_function *cached_fnc = NULL;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_get_errhandler(win, errhandler);
+
     /* Only user-specified window error handler is cached, because
      * standard does not say whether a window has default error handler. */
     CSPU_win_errhan_get(win, &cached_errhandler, &cached_fnc);

--- a/src/user/errhan/win_set_errhandler.c
+++ b/src/user/errhan/win_set_errhandler.c
@@ -13,6 +13,10 @@ int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler)
     int mpi_errno = MPI_SUCCESS;
     MPI_Win_errhandler_function *errhandler_fnc = NULL;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_set_errhandler(win, errhandler);
+
     if (errhandler != MPI_ERRORS_ARE_FATAL && errhandler != MPI_ERRORS_RETURN) {
         /* Get cached user function on this handler */
         CSPU_errhan_get_fnc(errhandler, (void **) (&errhandler_fnc));

--- a/src/user/init/finalize.c
+++ b/src/user/init/finalize.c
@@ -114,6 +114,10 @@ int MPI_Finalize(void)
     int mpi_errno = MPI_SUCCESS;
     int user_local_rank;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Finalize();
+
     CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.user.u_local_comm, &user_local_rank));
 
     /* notify ghost processes to finalize */

--- a/src/user/rma/accumulate.c
+++ b/src/user/rma/accumulate.c
@@ -72,6 +72,10 @@ static int accumulate_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Accumulate(origin_addr, origin_count,       \
+           origin_datatype, target_rank, target_disp, target_count,     \
+           target_datatype, op, win)
+
 int MPI_Accumulate(const void *origin_addr, int origin_count,
                    MPI_Datatype origin_datatype,
                    int target_rank, MPI_Aint target_disp,
@@ -79,6 +83,10 @@ int MPI_Accumulate(const void *origin_addr, int origin_count,
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -99,9 +107,7 @@ int MPI_Accumulate(const void *origin_addr, int origin_count,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Accumulate(origin_addr, origin_count,
-                               origin_datatype, target_rank, target_disp, target_count,
-                               target_datatype, op, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/compare_and_swap.c
+++ b/src/user/rma/compare_and_swap.c
@@ -68,12 +68,19 @@ static int compare_and_swap_impl(const void *origin_addr, const void *compare_ad
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Compare_and_swap(origin_addr, compare_addr, result_addr,    \
+            datatype, target_rank, target_disp, win)
+
 int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr,
                          void *result_addr, MPI_Datatype datatype, int target_rank,
                          MPI_Aint target_disp, MPI_Win win)
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -93,8 +100,7 @@ int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Compare_and_swap(origin_addr, compare_addr, result_addr,
-                                     datatype, target_rank, target_disp, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/fetch_and_op.c
+++ b/src/user/rma/fetch_and_op.c
@@ -68,12 +68,19 @@ static int fetch_and_op_impl(const void *origin_addr, void *result_addr,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Fetch_and_op(origin_addr, result_addr, datatype, target_rank,   \
+            target_disp, op, win)
+
 int MPI_Fetch_and_op(const void *origin_addr, void *result_addr,
                      MPI_Datatype datatype, int target_rank, MPI_Aint target_disp,
                      MPI_Op op, MPI_Win win)
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -93,8 +100,7 @@ int MPI_Fetch_and_op(const void *origin_addr, void *result_addr,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Fetch_and_op(origin_addr, result_addr, datatype, target_rank,
-                                 target_disp, op, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/get.c
+++ b/src/user/rma/get.c
@@ -106,6 +106,9 @@ static int get_impl(void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Get(origin_addr, origin_count, origin_datatype, \
+target_rank, target_disp, target_count, target_datatype, win)
+
 int MPI_Get(void *origin_addr, int origin_count,
             MPI_Datatype origin_datatype,
             int target_rank, MPI_Aint target_disp,
@@ -113,6 +116,10 @@ int MPI_Get(void *origin_addr, int origin_count,
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -132,8 +139,7 @@ int MPI_Get(void *origin_addr, int origin_count,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Get(origin_addr, origin_count, origin_datatype,
-                        target_rank, target_disp, target_count, target_datatype, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/get_accumulate.c
+++ b/src/user/rma/get_accumulate.c
@@ -72,6 +72,11 @@ static int get_accumulate_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Get_accumulate(origin_addr, origin_count, origin_datatype,  \
+        result_addr, result_count, result_datatype,                                     \
+        target_rank, target_disp, target_count,                                         \
+        target_datatype, op, win)
+
 int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
                        void *result_addr, int result_count, MPI_Datatype result_datatype,
                        int target_rank, MPI_Aint target_disp, int target_count,
@@ -79,6 +84,10 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype o
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -100,10 +109,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype o
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Get_accumulate(origin_addr, origin_count, origin_datatype,
-                                   result_addr, result_count, result_datatype,
-                                   target_rank, target_disp, target_count,
-                                   target_datatype, op, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/put.c
+++ b/src/user/rma/put.c
@@ -105,6 +105,9 @@ static int put_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Put(origin_addr, origin_count, origin_datatype, target_rank,    \
+target_disp, target_count, target_datatype, win)
+
 int MPI_Put(const void *origin_addr, int origin_count,
             MPI_Datatype origin_datatype,
             int target_rank, MPI_Aint target_disp,
@@ -112,6 +115,10 @@ int MPI_Put(const void *origin_addr, int origin_count,
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -132,8 +139,7 @@ int MPI_Put(const void *origin_addr, int origin_count,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Put(origin_addr, origin_count, origin_datatype, target_rank,
-                        target_disp, target_count, target_datatype, win);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/raccumulate.c
+++ b/src/user/rma/raccumulate.c
@@ -98,6 +98,10 @@ static int raccumulate_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Raccumulate(origin_addr, origin_count,  \
+                                origin_datatype, target_rank, target_disp, target_count,    \
+                                target_datatype, op, win, request)
+
 int MPI_Raccumulate(const void *origin_addr, int origin_count,
                     MPI_Datatype origin_datatype,
                     int target_rank, MPI_Aint target_disp,
@@ -106,6 +110,10 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count,
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -126,9 +134,7 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Raccumulate(origin_addr, origin_count,
-                                origin_datatype, target_rank, target_disp, target_count,
-                                target_datatype, op, win, request);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/rget.c
+++ b/src/user/rma/rget.c
@@ -133,12 +133,19 @@ static int rget_impl(void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Rget(origin_addr, origin_count, origin_datatype,    \
+target_rank, target_disp, target_count, target_datatype, win, request)
+
 int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
              int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype,
              MPI_Win win, MPI_Request * request)
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -159,8 +166,7 @@ int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Rget(origin_addr, origin_count, origin_datatype,
-                         target_rank, target_disp, target_count, target_datatype, win, request);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/rget_accumulate.c
+++ b/src/user/rma/rget_accumulate.c
@@ -99,6 +99,11 @@ static int rget_accumulate_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Rget_accumulate(origin_addr, origin_count, origin_datatype, \
+                                    result_addr, result_count, result_datatype,         \
+                                    target_rank, target_disp, target_count,             \
+                                    target_datatype, op, win, request)
+
 int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
                         void *result_addr, int result_count, MPI_Datatype result_datatype,
                         int target_rank, MPI_Aint target_disp, int target_count,
@@ -106,6 +111,10 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype 
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -127,10 +136,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype 
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Rget_accumulate(origin_addr, origin_count, origin_datatype,
-                                    result_addr, result_count, result_datatype,
-                                    target_rank, target_disp, target_count,
-                                    target_datatype, op, win, request);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/rput.c
+++ b/src/user/rma/rput.c
@@ -129,12 +129,19 @@ static int rput_impl(const void *origin_addr, int origin_count,
     goto fn_exit;
 }
 
+#define ORIG_MPI_FNC() PMPI_Rput(origin_addr, origin_count, origin_datatype, target_rank,   \
+                         target_disp, target_count, target_datatype, win, request)
+
 int MPI_Rput(const void *origin_addr, int origin_count,
              MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp,
              int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request * request)
 {
     int mpi_errno = MPI_SUCCESS;
     CSPU_win_t *ug_win;
+
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return ORIG_MPI_FNC();
 
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
@@ -154,8 +161,7 @@ int MPI_Rput(const void *origin_addr, int origin_count,
     else {
         /* normal window */
         CSPU_ERRHAN_RESET_EXTOBJ();     /* reset before calling original MPI */
-        return PMPI_Rput(origin_addr, origin_count, origin_datatype, target_rank,
-                         target_disp, target_count, target_datatype, win, request);
+        return ORIG_MPI_FNC();
     }
 
   fn_exit:

--- a/src/user/rma/win_allocate.c
+++ b/src/user/rma/win_allocate.c
@@ -684,6 +684,10 @@ int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info,
     MPI_Aint *tmp_gather_buf = NULL;
     int tmp_bcast_buf[2];
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_allocate(size, disp_unit, info, user_comm, baseptr, win);
+
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_COMM_ERRHAN_SET_EXTOBJ();
 

--- a/src/user/rma/win_allocate_shared.c
+++ b/src/user/rma/win_allocate_shared.c
@@ -13,6 +13,10 @@ int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Com
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_allocate_shared(size, disp_unit, info, comm, baseptr, win);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
     CSP_CALLMPI(NOSTMT, PMPI_Win_allocate_shared(size, disp_unit, info, comm, baseptr, win));

--- a/src/user/rma/win_complete.c
+++ b/src/user/rma/win_complete.c
@@ -60,6 +60,10 @@ int MPI_Win_complete(MPI_Win win)
     int start_grp_size = 0;
     int i;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_complete(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_create.c
+++ b/src/user/rma/win_create.c
@@ -13,6 +13,10 @@ int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info,
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_create(base, size, disp_unit, info, comm, win);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/rma/win_create_dynamic.c
+++ b/src/user/rma/win_create_dynamic.c
@@ -12,6 +12,10 @@ int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_create_dynamic(info, comm, win);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
     CSP_CALLMPI(NOSTMT, PMPI_Win_create_dynamic(info, comm, win));

--- a/src/user/rma/win_fence.c
+++ b/src/user/rma/win_fence.c
@@ -44,6 +44,10 @@ int MPI_Win_fence(int assert, MPI_Win win)
     CSPU_win_t *ug_win;
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_fence(assert, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_flush.c
+++ b/src/user/rma/win_flush.c
@@ -73,6 +73,10 @@ int MPI_Win_flush(int target_rank, MPI_Win win)
     MPI_Win *win_ptr CSP_ATTRIBUTE((unused)) = NULL;
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_flush(target_rank, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_flush_all.c
+++ b/src/user/rma/win_flush_all.c
@@ -48,6 +48,10 @@ int MPI_Win_flush_all(MPI_Win win)
     int user_nprocs;
     int i;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_flush_all(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_flush_local.c
+++ b/src/user/rma/win_flush_local.c
@@ -71,6 +71,10 @@ int MPI_Win_flush_local(int target_rank, MPI_Win win)
     MPI_Win *win_ptr CSP_ATTRIBUTE((unused)) = NULL;
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_flush_local(target_rank, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_flush_local_all.c
+++ b/src/user/rma/win_flush_local_all.c
@@ -46,6 +46,10 @@ int MPI_Win_flush_local_all(MPI_Win win)
     int user_nprocs;
     int i CSP_ATTRIBUTE((unused));
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_flush_local_all(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_free.c
+++ b/src/user/rma/win_free.c
@@ -195,6 +195,10 @@ int MPI_Win_free(MPI_Win * win)
     CSPU_win_t *ug_win;
     int user_rank, user_nprocs, user_local_rank, user_local_nprocs;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_free(win);
+
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();
 

--- a/src/user/rma/win_get_attr.c
+++ b/src/user/rma/win_get_attr.c
@@ -13,6 +13,10 @@ int MPI_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val, int *flag
     CSPU_win_t *ug_win;
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_get_attr(win, win_keyval, attribute_val, flag);
+
     CSPU_fetch_ug_win_from_cache(win, &ug_win);
 
     if (ug_win == NULL) {

--- a/src/user/rma/win_lock.c
+++ b/src/user/rma/win_lock.c
@@ -86,6 +86,10 @@ int MPI_Win_lock(int lock_type, int target_rank, int assert, MPI_Win win)
     int mpi_errno = MPI_SUCCESS;
     int user_rank;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_lock(lock_type, target_rank, assert, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_lock_all.c
+++ b/src/user/rma/win_lock_all.c
@@ -16,6 +16,10 @@ int MPI_Win_lock_all(int assert, MPI_Win win)
     int user_nprocs;
     int i;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_lock_all(assert, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_post.c
+++ b/src/user/rma/win_post.c
@@ -101,6 +101,10 @@ int MPI_Win_post(MPI_Group group, int assert, MPI_Win win)
     int post_grp_size = 0;
     int i CSP_ATTRIBUTE((unused));
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_post(group, assert, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_start.c
+++ b/src/user/rma/win_start.c
@@ -87,6 +87,10 @@ int MPI_Win_start(MPI_Group group, int assert, MPI_Win win)
     int i;
     int user_rank;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_start(group, assert, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_sync.c
+++ b/src/user/rma/win_sync.c
@@ -15,6 +15,10 @@ int MPI_Win_sync(MPI_Win win)
     int user_rank = 0, user_nprocs = 0;
     int i;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_sync(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_test.c
+++ b/src/user/rma/win_test.c
@@ -15,6 +15,10 @@ int MPI_Win_test(MPI_Win win, int *flag)
     int mpi_errno = MPI_SUCCESS;
     int post_grp_size = 0;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_test(win, flag);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_unlock.c
+++ b/src/user/rma/win_unlock.c
@@ -51,6 +51,10 @@ int MPI_Win_unlock(int target_rank, MPI_Win win)
     int mpi_errno = MPI_SUCCESS;
     int user_rank;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_unlock(target_rank, win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_unlock_all.c
+++ b/src/user/rma/win_unlock_all.c
@@ -16,6 +16,10 @@ int MPI_Win_unlock_all(MPI_Win win)
     int user_nprocs;
     int i;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_unlock_all(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/rma/win_wait.c
+++ b/src/user/rma/win_wait.c
@@ -86,6 +86,10 @@ int MPI_Win_wait(MPI_Win win)
     int mpi_errno = MPI_SUCCESS;
     int post_grp_size = 0;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Win_wait(win);
+
     CSPU_THREAD_OBJ_CS_LOCAL_DCL();
     CSPU_ERRHAN_EXTOBJ_LOCAL_DCL();
     CSPU_WIN_ERRHAN_SET_EXTOBJ();

--- a/src/user/spawn/comm_accept.c
+++ b/src/user/spawn/comm_accept.c
@@ -13,6 +13,10 @@ int MPI_Comm_accept(const char *port_name, MPI_Info info, int root, MPI_Comm com
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_accept(port_name, info, root, comm, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/spawn/comm_connect.c
+++ b/src/user/spawn/comm_connect.c
@@ -13,6 +13,10 @@ int MPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm co
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Comm_connect(port_name, info, root, comm, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/topo/cart_create.c
+++ b/src/user/topo/cart_create.c
@@ -13,6 +13,10 @@ int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[],
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Cart_create(comm_old, ndims, dims, periods, reorder, comm_cart);
+
     if (comm_old == MPI_COMM_WORLD)
         comm_old = CSP_COMM_USER_WORLD;
 

--- a/src/user/topo/cart_sub.c
+++ b/src/user/topo/cart_sub.c
@@ -14,6 +14,10 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm * newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Cart_sub(comm, remain_dims, newcomm);
+
     if (comm == MPI_COMM_WORLD)
         comm = CSP_COMM_USER_WORLD;
 

--- a/src/user/topo/dist_gr_create.c
+++ b/src/user/topo/dist_gr_create.c
@@ -15,6 +15,11 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Dist_graph_create(comm_old, n, sources, degrees,
+                                      destinations, weights, info, reorder, comm_dist_graph);
+
     if (comm_old == MPI_COMM_WORLD)
         comm_old = CSP_COMM_USER_WORLD;
 

--- a/src/user/topo/dist_gr_create_adj.c
+++ b/src/user/topo/dist_gr_create_adj.c
@@ -17,6 +17,13 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Dist_graph_create_adjacent(comm_old, indegree, sources,
+                                               sourceweights, outdegree,
+                                               destinations, destweights,
+                                               info, reorder, comm_dist_graph);
+
     if (comm_old == MPI_COMM_WORLD)
         comm_old = CSP_COMM_USER_WORLD;
 

--- a/src/user/topo/graph_create.c
+++ b/src/user/topo/graph_create.c
@@ -13,6 +13,10 @@ int MPI_Graph_create(MPI_Comm comm_old, int nnodes, const int indx[],
 {
     int mpi_errno = MPI_SUCCESS;
 
+    /* Skip internal processing when disabled */
+    if (CSP_IS_DISABLED)
+        return PMPI_Graph_create(comm_old, nnodes, indx, edges, reorder, comm_graph);
+
     if (comm_old == MPI_COMM_WORLD)
         comm_old = CSP_COMM_USER_WORLD;
 

--- a/test/runtest.in
+++ b/test/runtest.in
@@ -72,7 +72,7 @@ if [ "$test_mode" = "m" ]; then
 
     if [ "x$NG" != "x" ]; then
         # overwrite mode if input is valid
-        if [ "$NG" -ge "1" ]; then
+        if [ "$NG" -ge "0" ]; then
             test_ng=$NG
         fi
     fi
@@ -250,7 +250,7 @@ function exec_all_programs()
 {
     mpiexec=$1
 
-    if [ "x$CSP_NG" = "x" ] || [ "$CSP_NG" -lt "1" ];then
+    if [ "x$CSP_NG" = "x" ] || [ "$CSP_NG" -lt "0" ];then
         echo "invalid CSP_NG=$CSP_NG !"
         exit
     fi
@@ -312,6 +312,11 @@ if [ "$test_mode" = "a" ];then
 
     np=16
     ng=2
+    export CSP_NG=$ng
+    exec_all_programs "$test_mpiexec $np"
+
+    np=4
+    ng=0
     export CSP_NG=$ng
     exec_all_programs "$test_mpiexec $np"
 else


### PR DESCRIPTION
Set CSP_NG=0 to disable any internal processing and directly redirect
to original MPI call, no ghost process exist. Note that, setting
ASYNC_CONFIG to off only allows user to disable asynchronous
progress on the user processes, but the ghost processes are still
kept aside.