### PR TITLE
Added hwloc based topology optimization.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/hwloc"]
+	path = src/hwloc
+	url = https://github.com/open-mpi/hwloc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/hwloc"]
 	path = src/hwloc
 	url = https://github.com/open-mpi/hwloc
+[submodule "src/openpa"]
+	path = src/openpa
+	url = http://git.mpich.org/openpa.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,11 +10,20 @@ include_HEADERS = include/casper.h
 
 libcasper_la_SOURCES =
 
+external_subdirs = @hwlocsrcdir@
+external_ldflags = @hwloclibdir@
+convenience_libs = @hwloclib@
+
+libcasper_la_LDFLAGS = $(external_ldflags)
+libcasper_la_LIBADD = $(convenience_libs)
+EXTRA_libcasper_la_DEPENDENCIES = $(convenience_libs)
+
 include src/Makefile.mk
 
 EXTRA_DIST = CHANGES COPYRIGHT maint autogen.sh
 
-DIST_SUBDIRS = test
+DIST_SUBDIRS = test ${external_subdirs}
+SUBDIRS = ${external_subdirs}
 
 buildtests:
 	(cd test && make)

--- a/autogen.sh
+++ b/autogen.sh
@@ -132,6 +132,12 @@ for subdir in $subdirs ; do
 	echo "done"
 done
 
+# apply patch for submodules
+echo ""
+echo_n "Applying patch to hwloc... "
+( cd src/hwloc && git am --3way ../../maint/patches/pre/hwloc/*.patch )
+echo "done"
+
 # autogen for submodules
 extdirs="src/hwloc"
 for extdir in $extdirs ; do

--- a/autogen.sh
+++ b/autogen.sh
@@ -132,9 +132,21 @@ for subdir in $subdirs ; do
 	echo "done"
 done
 
+# autogen for submodules
+extdirs="src/hwloc"
+for extdir in $extdirs ; do
+   if [ -d "$extdir" -o -L "$extdir" ] ; then
+       echo ""
+       echo "Running third-party initialization in $extdir"
+       (cd $extdir && ./autogen.sh) || exit 1
+   fi
+done
+
 # generate configures
 for subdir in . $subdirs ; do
 	echo ""
 	echo "Generating configure in $subdir"
 	(cd $subdir && autoreconf -vif) || exit 1
 done
+
+

--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -626,13 +626,6 @@ if test "$enable_strict_done" != "yes" ; then
        	  pac_cc_strict_flags="-O2"
        fi
        pac_cc_strict_flags="$pac_cc_strict_flags $pac_common_strict_flags"
-       case "$enable_posix" in
-            no)   : ;;
-            1995) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=199506L],[pac_cc_strict_flags]) ;;
-            2001) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=200112L],[pac_cc_strict_flags]) ;;
-            2008) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=200809L],[pac_cc_strict_flags]) ;;
-            *)    AC_MSG_ERROR([internal error, unexpected POSIX version: '$enable_posix']) ;;
-       esac
        # We only allow one of strict-C99 or strict-C89 to be
        # enabled. If C99 is enabled, we automatically disable C89.
        if test "${enable_c99}" = "yes" ; then
@@ -644,6 +637,19 @@ if test "$enable_strict_done" != "yes" ; then
        elif test "${enable_c89}" = "yes" ; then
        	  PAC_APPEND_FLAG([-std=c89],[pac_cc_strict_flags])
        	  PAC_APPEND_FLAG([-Wdeclaration-after-statement],[pac_cc_strict_flags])
+       fi
+       # POSIX 2001 should be used with C99. But the default standard for some
+       # compilers are not C99. We must test the support of POSIX 2001 after
+       # testing C99.
+       case "$enable_posix" in
+            no)   : ;;
+            1995) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=199506L],[pac_cc_strict_flags]) ;;
+            2001) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=200112L],[pac_cc_strict_flags]) ;;
+            2008) PAC_APPEND_FLAG([-D_POSIX_C_SOURCE=200809L],[pac_cc_strict_flags]) ;;
+            *)    AC_MSG_ERROR([internal error, unexpected POSIX version: '$enable_posix']) ;;
+       esac
+       if test "$enable_posix" != "no" ; then
+           AS_CASE([$host],[*-*-darwin*], [PAC_APPEND_FLAG([-D_DARWIN_C_SOURCE],[pac_cc_strict_flags])])
        fi
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,16 @@ AC_SUBST(CASPER_NUMVERSION)
 
 AC_CONFIG_AUX_DIR(confdb)
 AC_CONFIG_MACRO_DIR(confdb)
+
+# needed by hwloc in embedded mode.  Must come very early to avoid
+# bizarre expansion ordering warnings
+AC_CANONICAL_TARGET
+AC_ARG_PROGRAM
+
+# also needed by hwloc in embedded mode, must also come early for expansion
+# ordering reasons
+AC_USE_SYSTEM_EXTENSIONS
+
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability-recursive silent-rules foreign 1.12.3 subdir-objects])
 
 # Bug in libtool adds -O2 and -g by default
@@ -98,7 +108,7 @@ AC_CONFIG_HEADER([include/casperconf.h])
 PAC_PUSH_FLAG([CFLAGS])
 LT_INIT()
 PAC_POP_FLAG([CFLAGS])
-
+ 
 CONFIGURE_ARGS_CLEAN="$CONFIGURE_ARGS_CLEAN CC=$CC CFLAGS=$CFLAGS "
 CONFIGURE_ARGS_CLEAN="$CONFIGURE_ARGS_CLEAN LDFLAGS=$LDFLAGS LIBS=$LIBS CPPFLAGS=$CPPFLAGS  "
 CONFIGURE_ARGS_CLEAN="$CONFIGURE_ARGS_CLEAN $BUILD_INFO LT_SYS_LIBRARY_PATH=$LT_SYS_LIBRARY_PATH CPP=$CPP"
@@ -217,28 +227,71 @@ if test "$enable_thread_safety" = "yes"; then
 fi
 
 # HWLOC library (optional)
+
+# Unconditionally include the hwloc macros, even if we are using an
+# external hwloc (or hwloc is disabled). This is needed for the
+# AM_CONDITIONALS that we will set later.
+m4_include([src/hwloc/config/hwloc.m4])
+m4_include([src/hwloc/config/hwloc_check_attributes.m4])
+m4_include([src/hwloc/config/hwloc_check_visibility.m4])
+m4_include([src/hwloc/config/hwloc_check_vendor.m4])
+m4_include([src/hwloc/config/hwloc_components.m4])
+m4_include([src/hwloc/config/hwloc_pkg.m4])
+
+hwlocsrcdir=""
+AC_SUBST([hwlocsrcdir])
+hwloclibdir=""
+AC_SUBST([hwloclibdir])
+hwloclib=""
+AC_SUBST([hwloclib])
+ 
 have_hwloc=no
-AC_ARG_WITH(hwloc, [AC_HELP_STRING([--with-hwloc[=DIR]],
+AC_ARG_WITH(hwloc, [AC_HELP_STRING([--with-hwloc[=DIR|embedded|no]],
                 [Use the specified HWLOC installation; Header file hwloc.h 
                 should be in dir/include, and libhwloc should be in dir/lib. 
-                Disabled by default])],,with_hwloc=no)
+                Use embedded hwloc by default])],,with_hwloc=embedded)
 
 # This needs to be an absolute pathname.
 # We do not support embedded mode because linking its static library to
 # casper dynamic library is not portable.
-if test "$with_hwloc" = "no" ; then
-    AC_MSG_WARN([No hwloc library.])
-else
-    CFLAGS="$CFLAGS -I$with_hwloc/include"
-    LDFLAGS="$LDFLAGS -L$with_hwloc/lib"
-    LIBS="$LIBS -lhwloc"
-    AC_CHECK_HEADERS(hwloc.h)
-    AC_CHECK_LIB([hwloc],[hwloc_topology_init],have_hwloc=yes,AC_MSG_ERROR([unable to find hwloc_get_nbobjs_by_type.]))
-fi
+case "$with_hwloc" in
+    embedded)
+        HWLOC_SETUP_CORE([src/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
+        # Only build hwloc in embedded mode
+        if test "$have_hwloc" = "yes" ; then
+            use_embedded_hwloc=yes
+            CFLAGS="$HWLOC_EMBEDDED_CFLAGS $CFLAGS"
+            CPPFLAGS="$HWLOC_EMBEDDED_CPPFLAGS $CPPFLAGS"
+            LIBS="$HWLOC_EMBEDDED_LIBS $LIBS"
+            hwlocsrcdir="src/hwloc"
+            hwloclib="src/hwloc/src/libhwloc_embedded.la"
+        fi
+    ;;
+    no)
+        AC_MSG_WARN([No hwloc library.])
+    ;;
+    *)
+        CFLAGS="$CFLAGS -I$with_hwloc/include"
+        LDFLAGS="$LDFLAGS -L$with_hwloc/lib"
+        LIBS="$LIBS -lhwloc"
+        AC_CHECK_HEADERS(hwloc.h)
+        AC_CHECK_LIB([hwloc],[hwloc_topology_init],have_hwloc=yes,AC_MSG_ERROR([unable to find hwloc_topology_init.]))
+        
+        hwloclib="-lhwloc"
+        if test -d ${with_hwloc}/lib64 ; then
+            hwloclibdir="-L${with_hwloc}/lib64"
+        else
+            hwloclibdir="-L${with_hwloc}/lib"
+        fi
+    ;;
+esac
+
+HWLOC_DO_AM_CONDITIONALS
 if test "$have_hwloc" = "yes" ; then
     AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
     AC_DEFINE(CSP_ENABLE_TOPO_OPT,1,[Define if topology optimization is enabled. Require hwloc.])
 fi
+
 AM_CONDITIONAL([csp_have_topo_opt], [test "$have_hwloc" = "yes"])
 
 # check for attribute support

--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,31 @@ if test "$enable_thread_safety" = "yes"; then
                        [Thread package to implement critical section])
 fi
 
+# HWLOC library (optional)
+have_hwloc=no
+AC_ARG_WITH(hwloc, [AC_HELP_STRING([--with-hwloc[=DIR]],
+                [Use the specified HWLOC installation; Header file hwloc.h 
+                should be in dir/include, and libhwloc should be in dir/lib. 
+                Disabled by default])],,with_hwloc=no)
+
+# This needs to be an absolute pathname.
+# We do not support embedded mode because linking its static library to
+# casper dynamic library is not portable.
+if test "$with_hwloc" = "no" ; then
+    AC_MSG_WARN([No hwloc library.])
+else
+    CFLAGS="$CFLAGS -I$with_hwloc/include"
+    LDFLAGS="$LDFLAGS -L$with_hwloc/lib"
+    LIBS="$LIBS -lhwloc"
+    AC_CHECK_HEADERS(hwloc.h)
+    AC_CHECK_LIB([hwloc],[hwloc_topology_init],have_hwloc=yes,AC_MSG_ERROR([unable to find hwloc_get_nbobjs_by_type.]))
+fi
+if test "$have_hwloc" = "yes" ; then
+    AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+    AC_DEFINE(CSP_ENABLE_TOPO_OPT,1,[Define if topology optimization is enabled. Require hwloc.])
+fi
+AM_CONDITIONAL([csp_have_topo_opt], [test "$have_hwloc" = "yes"])
+
 # check for attribute support
 PAC_C_GNU_ATTRIBUTE
 

--- a/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
+++ b/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
@@ -1,0 +1,48 @@
+From 9ef121467a3d187de2e47a7b6def17dbaa9f1e85 Mon Sep 17 00:00:00 2001
+From: Pavan Balaji <balaji@anl.gov>
+Date: Fri, 13 Oct 2017 16:02:08 -0500
+Subject: [PATCH 2/3] hwloc: separated visibility cflags for better control.
+
+---
+ config/hwloc.m4 | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/config/hwloc.m4 b/config/hwloc.m4
+index cda92d08dfb9..c153e520f888 100644
+--- a/config/hwloc.m4
++++ b/config/hwloc.m4
+@@ -316,9 +316,6 @@ EOF])
+     _HWLOC_C_COMPILER_VENDOR([hwloc_c_vendor])
+     _HWLOC_CHECK_ATTRIBUTES
+     _HWLOC_CHECK_VISIBILITY
+-    HWLOC_CFLAGS="$HWLOC_FLAGS $HWLOC_VISIBILITY_CFLAGS"
+-    AS_IF([test "$HWLOC_VISIBILITY_CFLAGS" != ""],
+-          [AC_MSG_WARN(["$HWLOC_VISIBILITY_CFLAGS" has been added to the hwloc CFLAGS])])
+ 
+     # Make sure the compiler returns an error code when function arg
+     # count is wrong, otherwise sched_setaffinity checks may fail.
+@@ -1179,15 +1176,21 @@ EOF])
+ 
+     AS_IF([test "$hwloc_mode" = "embedded"],
+           [HWLOC_EMBEDDED_CFLAGS=$HWLOC_CFLAGS
++           HWLOC_EMBEDDED_VISIBILITY_CFLAGS=$HWLOC_VISIBILITY_CFLAGS
+            HWLOC_EMBEDDED_CPPFLAGS=$HWLOC_CPPFLAGS
+            HWLOC_EMBEDDED_LDADD='$(HWLOC_top_builddir)/src/libhwloc_embedded.la'
+            HWLOC_EMBEDDED_LIBS=$HWLOC_LIBS
+            HWLOC_LIBS=])
+     AC_SUBST(HWLOC_EMBEDDED_CFLAGS)
++    AC_SUBST(HWLOC_EMBEDDED_VISIBILITY_CFLAGS)
+     AC_SUBST(HWLOC_EMBEDDED_CPPFLAGS)
+     AC_SUBST(HWLOC_EMBEDDED_LDADD)
+     AC_SUBST(HWLOC_EMBEDDED_LIBS)
+ 
++    HWLOC_CFLAGS="$HWLOC_FLAGS $HWLOC_VISIBILITY_CFLAGS $HWLOC_CFLAGS"
++    AS_IF([test "$HWLOC_VISIBILITY_CFLAGS" != ""],
++          [AC_MSG_WARN(["$HWLOC_VISIBILITY_CFLAGS" has been added to the hwloc CFLAGS])])
++
+     # Always generate these files
+     AC_CONFIG_FILES(
+         hwloc_config_prefix[Makefile]
+-- 
+2.14.2
+

--- a/src/common/Makefile.mk
+++ b/src/common/Makefile.mk
@@ -7,3 +7,7 @@ include $(top_srcdir)/src/common/init/Makefile.mk
 include $(top_srcdir)/src/common/msg/Makefile.mk
 include $(top_srcdir)/src/common/error/Makefile.mk
 include $(top_srcdir)/src/common/util/Makefile.mk
+
+if csp_have_topo_opt
+include $(top_srcdir)/src/common/topo/Makefile.mk
+endif

--- a/src/common/include/Makefile.mk
+++ b/src/common/include/Makefile.mk
@@ -9,3 +9,7 @@ libcasper_la_SOURCES += src/common/include/csp.h \
 			src/common/include/csp_msg.h \
 			src/common/include/csp_thread.h \
 			src/common/include/csp_util.h
+
+if csp_have_topo_opt
+libcasper_la_SOURCES += src/common/include/csp_topo.h
+endif

--- a/src/common/include/csp.h
+++ b/src/common/include/csp.h
@@ -21,6 +21,9 @@
 #if defined(CSP_ENABLE_THREAD_SAFE)
 #include "csp_thread.h"
 #endif
+#if defined(CSP_ENABLE_TOPO_OPT)
+#include "csp_topo.h"
+#endif
 
 /* #define CSP_ENABLE_GRANT_LOCK_HIDDEN_BYTE */
 
@@ -132,6 +135,12 @@ typedef struct CSP_env_param {
 
     int verbose;                /* verbose level. print configuration information. */
     CSP_async_config_t async_config;
+
+#if defined(CSP_ENABLE_TOPO_OPT)
+    struct {
+        CSP_topo_domain_type_t domain;
+    } topo;
+#endif
 } CSP_env_param_t;
 
 
@@ -176,6 +185,9 @@ typedef struct CSP_proc {
     int num_nodes;
     int wrank;
 
+    MPI_Comm wcomm;             /* MPI_COMM_WORLD with optimized topology.
+                                 * All internal access to comm_world should
+                                 * use this object.*/
     MPI_Comm local_comm;        /* Includes all processes on local node. */
     MPI_Group wgroup;
 

--- a/src/common/include/csp_topo.h
+++ b/src/common/include/csp_topo.h
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * (C) 2016 by Argonne National Laboratory.
+ *     See COPYRIGHT in top-level directory.
+ */
+#ifndef TOPO_H_INCLUDED
+#define TOPO_H_INCLUDED
+
+#ifdef HAVE_HWLOC
+#include <hwloc.h>
+#endif
+
+typedef enum CSP_topo_domain_type {
+    CSP_TOPO_DOMAIN_MACHINE,
+    CSP_TOPO_DOMAIN_NUMA,
+    CSP_TOPO_DOMAIN_SOCK,
+} CSP_topo_domain_type_t;
+
+extern int CSP_topo_remap(void);
+
+#endif /* TOPO_H_INCLUDED */

--- a/src/common/topo/Makefile.mk
+++ b/src/common/topo/Makefile.mk
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2016. See COPYRIGHT in top-level directory.
+#
+
+libcasper_la_SOURCES += src/common/topo/topo.c

--- a/src/common/topo/topo.c
+++ b/src/common/topo/topo.c
@@ -1,0 +1,434 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * (C) 2016 by Argonne National Laboratory.
+ *     See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <mpi.h>
+#include "csp.h"
+
+#ifdef TOPO_DEBUG
+static int dbg_wrank = 0;
+#define TOPO_DBG_PRINT(str,...) do { \
+    fprintf(stdout, "[CSP] %s rank %d: "str, __FUNCTION__, dbg_wrank, ## __VA_ARGS__); \
+    fflush(stdout); \
+    } while (0)
+#else
+#define TOPO_DBG_PRINT(str,...) do { } while (0)
+#endif
+
+typedef struct CSP_topo_info {
+    hwloc_topology_t topo;
+    int npus;
+} CSP_topo_info_t;
+
+typedef struct CSP_topo_bind_info {
+    int domain_idx;
+
+    /* Debug use only */
+    char mask[512];
+    int npus;
+} CSP_topo_bind_info_t;
+
+typedef struct CSP_topo_map {
+    int ndomains;
+    int bind_ndomains;
+    hwloc_obj_type_t domain_obj_type;
+    MPI_Comm comm;
+    int *domain_sizes;          /* Number of processes in each domain */
+    CSP_topo_bind_info_t *bind_infos;
+} CSP_topo_map_t;
+
+static CSP_topo_info_t CSP_topo_info;
+
+static inline int topo_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int num_machine = 1, num_core = 1;
+    int hwloc_err = 0;
+
+    hwloc_err = hwloc_topology_init(&CSP_topo_info.topo);
+    if (hwloc_err < 0) {
+        fprintf(stderr, "failed to init the topology\n");
+        goto fn_fail;
+    }
+
+    hwloc_err = hwloc_topology_load(CSP_topo_info.topo);
+    if (hwloc_err < 0) {
+        fprintf(stderr, "failed to load the topology\n");
+        hwloc_topology_destroy(CSP_topo_info.topo);
+        goto fn_fail;
+    }
+
+    CSP_topo_info.npus = hwloc_get_nbobjs_by_type(CSP_topo_info.topo, HWLOC_OBJ_PU);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    mpi_errno = CSP_get_error_code(CSP_ERR_INTERN);
+    goto fn_exit;
+}
+
+static inline void topo_destroy(void)
+{
+    hwloc_topology_destroy(CSP_topo_info.topo);
+}
+
+static inline int topo_get_cpubind(CSP_topo_bind_info_t * bind_info,
+                                   hwloc_obj_type_t domain_obj_type)
+{
+    hwloc_const_bitmap_t cset_all;
+    hwloc_bitmap_t myset = NULL;
+    hwloc_obj_t bind_obj = NULL, domain_obj = NULL;
+    int hwloc_err = 0;
+
+    /* Reset indexes */
+    bind_info->domain_idx = -1;
+
+    cset_all = hwloc_topology_get_topology_cpuset(CSP_topo_info.topo);
+
+    /* Get CPU binding of the current process */
+    myset = hwloc_bitmap_alloc();
+    if (!myset) {
+        fprintf(stderr, "Failed to allocate a bitmap\n");
+        goto fn_fail;
+    }
+
+    hwloc_err = hwloc_get_cpubind(CSP_topo_info.topo, myset, HWLOC_CPUBIND_PROCESS);
+    if (hwloc_err < 0) {
+        fprintf(stderr, "Failed to get cpu binding\n");
+        goto fn_fail;
+    }
+
+    if (hwloc_bitmap_isequal(myset, cset_all)) {
+        TOPO_DBG_PRINT("No binding found \n");
+    }
+    else {
+        /* Find domain index */
+        domain_obj = hwloc_get_next_obj_by_type(CSP_topo_info.topo, domain_obj_type, NULL);
+        while (domain_obj != NULL) {
+            if (hwloc_bitmap_isincluded(myset, domain_obj->cpuset)) {
+                bind_info->domain_idx = domain_obj->logical_index;
+                break;
+            }
+            domain_obj = hwloc_get_next_obj_by_type(CSP_topo_info.topo,
+                                                    domain_obj_type, domain_obj);
+        }
+        /* FIXME: throw more user friendly error. */
+        CSP_ASSERT(bind_info->domain_idx >= 0);
+
+        /* Info printing only. Encode bound PU indexes into a string. */
+        int puprev = -1, puidx = -1, strpos = 0;
+        memset(bind_info->mask, sizeof(bind_info->mask), 0);
+        bind_info->npus = hwloc_bitmap_weight(myset);
+        do {
+            puidx = hwloc_bitmap_next(myset, puprev);
+            puprev = puidx;
+
+            if (puidx >= 0 && sizeof(bind_info->mask) - strpos > sizeof(int)) {
+                int off = 0;
+                off = sprintf(bind_info->mask + strpos, "%d,", puidx);
+                strpos += off;  /* terminate char is not counted */
+            }
+        } while (puidx != -1);
+        /* Remove last comma. */
+        sprintf(bind_info->mask + strpos - 1, "%c", '\0');
+    }
+
+  fn_exit:
+    if (!myset)
+        hwloc_bitmap_free(myset);
+    return hwloc_err;
+  fn_fail:
+    goto fn_exit;
+}
+
+static inline void topo_free_map(CSP_topo_map_t * topo_map)
+{
+    if (topo_map->bind_infos != NULL)
+        free(topo_map->bind_infos);
+    if (topo_map->domain_sizes != NULL)
+        free(topo_map->domain_sizes);
+    topo_map->bind_infos = NULL;
+    topo_map->domain_sizes = NULL;
+}
+
+static inline int topo_load_comm_map(CSP_topo_domain_type_t domain_type, MPI_Comm comm,
+                                     CSP_topo_map_t * topo_map)
+{
+    hwloc_const_bitmap_t cset_all;
+    hwloc_bitmap_t myset = NULL;        /* FIXME: not portable. */
+    hwloc_obj_t bind_obj;
+    hwloc_obj_type_t domain_obj_type;
+    int hwloc_err = 0;
+    int mpi_errno = MPI_SUCCESS;
+    int i, myrank, size;
+
+    switch (domain_type) {
+    case CSP_TOPO_DOMAIN_MACHINE:
+        domain_obj_type = HWLOC_OBJ_MACHINE;
+        break;
+    case CSP_TOPO_DOMAIN_NUMA:
+        domain_obj_type = HWLOC_OBJ_NUMANODE;
+        break;
+    case CSP_TOPO_DOMAIN_SOCK:
+        domain_obj_type = HWLOC_OBJ_PACKAGE;
+        break;
+    default:
+        CSP_msg_print(CSP_MSG_ERROR, " Unknown topology domain type %d\n", domain_type);
+        goto fn_fail;
+    }
+
+    topo_map->comm = comm;
+    MPI_Comm_rank(topo_map->comm, &myrank);
+    MPI_Comm_size(topo_map->comm, &size);
+
+    topo_map->ndomains = hwloc_get_nbobjs_by_type(CSP_topo_info.topo, domain_obj_type);
+    topo_map->domain_sizes = (int *) CSP_calloc(topo_map->ndomains, sizeof(int));
+    topo_map->bind_infos = (CSP_topo_bind_info_t *) CSP_calloc(size, sizeof(CSP_topo_bind_info_t));
+    topo_map->domain_obj_type = domain_obj_type;
+
+    /* get my bind info */
+    hwloc_err = topo_get_cpubind(&topo_map->bind_infos[myrank], domain_obj_type);
+    if (hwloc_err < 0)
+        goto fn_fail;
+
+    /* exchange */
+    CSP_CALLMPI(JUMP, PMPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                                     topo_map->bind_infos, sizeof(CSP_topo_bind_info_t), MPI_BYTE,
+                                     comm));
+    for (i = 0; i < size; i++) {
+        CSP_ASSERT(topo_map->bind_infos[i].domain_idx < topo_map->ndomains);
+        topo_map->domain_sizes[topo_map->bind_infos[i].domain_idx]++;
+    }
+
+    /* Get number of bound domains */
+    topo_map->bind_ndomains = 0;
+    for (i = 0; i < topo_map->ndomains; i++) {
+        if (topo_map->domain_sizes[i] > 0)
+            topo_map->bind_ndomains++;
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    mpi_errno = CSP_get_error_code(CSP_ERR_INTERN);
+    goto fn_exit;
+}
+
+static inline void topo_print_comm_map(CSP_topo_map_t topo_map)
+{
+    int i, comm_myrank, comm_size;
+
+    MPI_Comm_size(topo_map.comm, &comm_size);
+    MPI_Comm_rank(topo_map.comm, &comm_myrank);
+
+    if (comm_myrank == 0 && (CSP_ENV.verbose & (int) CSP_MSG_INFO)) {
+        for (i = 0; i < comm_size; i++) {
+            CSP_msg_print(CSP_MSG_INFO, "TOPO: rank %d, domain_idx=%d "
+                          "(type %s x %d/%d) bound %d PUs(%s)\n",
+                          i, topo_map.bind_infos[i].domain_idx,
+                          hwloc_obj_type_string(topo_map.domain_obj_type),
+                          topo_map.ndomains, topo_map.bind_ndomains,
+                          topo_map.bind_infos[i].npus, topo_map.bind_infos[i].mask);
+        }
+    }
+}
+
+static inline int topo_check_remap(CSP_topo_map_t topo_map, int *local_remap_flag,
+                                   int *global_remap_flag)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int local_rank, local_nproc;
+    int domain_num_g, domain_np;
+    int didx, i, map_uneven = 0;
+    int ordered = 1;
+
+    CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.local_comm, &local_rank));
+    CSP_CALLMPI(JUMP, PMPI_Comm_size(CSP_PROC.local_comm, &local_nproc));
+
+    domain_np = local_nproc / topo_map.bind_ndomains;
+    domain_num_g = CSP_ENV.num_g / topo_map.bind_ndomains;
+
+    *local_remap_flag = 1;
+
+    /* Do remapping only when more than one domain is set and ghosts is sufficient. */
+    if (topo_map.bind_ndomains < 2 || domain_num_g < 1) {
+        *local_remap_flag = 0;
+        if (local_rank == 0)
+            CSP_msg_print(CSP_MSG_INFO, "TOPO: insufficient domains or ghosts, no remap\n");
+        goto no_local_remap;
+    }
+
+    /* Do not remap uneven or mismatch domain distribution. */
+    for (didx = 0; didx < topo_map.ndomains; didx++) {
+        if (topo_map.domain_sizes[didx] > 0)    /* ignore zero domain */
+            map_uneven |= (domain_np != topo_map.domain_sizes[didx]);
+    }
+    if (map_uneven) {
+        *local_remap_flag = 0;
+        if (local_rank == 0)
+            CSP_msg_print(CSP_MSG_INFO, "TOPO: uneven, no remap\n");
+        goto no_local_remap;
+    }
+
+    /* Do not remap if optimal binding is already set. */
+    for (i = 0; i < CSP_ENV.num_g; i++)
+        ordered &= (topo_map.bind_infos[i].domain_idx == i / domain_num_g);
+    for (i = CSP_ENV.num_g; i < local_nproc; i++)
+        ordered &= (topo_map.bind_infos[i].domain_idx ==
+                    (i - CSP_ENV.num_g) / (domain_np - domain_num_g));
+    if (ordered) {
+        if (local_rank == 0)
+            CSP_msg_print(CSP_MSG_INFO, "TOPO: ordered, no remap\n");
+        *local_remap_flag = 0;
+    }
+
+  no_local_remap:
+    /* Check if any node reordered */
+    CSP_CALLMPI(JUMP, PMPI_Allreduce(local_remap_flag, global_remap_flag, 1, MPI_INT, MPI_BOR,
+                                     MPI_COMM_WORLD));
+
+    TOPO_DBG_PRINT("Check topology: local remap %d, global remap %d\n",
+                   *local_remap_flag, *global_remap_flag);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int CSP_topo_remap(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int local_rank, local_nproc;
+    CSP_topo_map_t topo_map;
+    int *remap_ranks = NULL, *domains_num_g_set = NULL, *world_remap_ranks = NULL;
+    MPI_Comm old_local_comm = MPI_COMM_NULL;
+    MPI_Group old_lgroup = MPI_GROUP_NULL, old_wgroup = MPI_GROUP_NULL;
+    int local_remap_flag = 0, global_remap_flag = 0;
+
+    mpi_errno = topo_init();
+    CSP_CHKMPIFAIL_JUMP(mpi_errno);
+
+#ifdef TOPO_DEBUG
+    CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.wcomm, &dbg_wrank));
+#endif
+
+    CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.local_comm, &local_rank));
+    CSP_CALLMPI(JUMP, PMPI_Comm_size(CSP_PROC.local_comm, &local_nproc));
+    CSP_CALLMPI(JUMP, PMPI_Comm_group(CSP_PROC.local_comm, &old_lgroup));
+
+    CSP_DBG_PRINT("before remap,I am %d in world, %d in local\n", CSP_PROC.wrank, local_rank);
+
+    mpi_errno = topo_load_comm_map(CSP_ENV.topo.domain, CSP_PROC.local_comm, &topo_map);
+    CSP_CHKMPIFAIL_JUMP(mpi_errno);
+
+    mpi_errno = topo_check_remap(topo_map, &local_remap_flag, &global_remap_flag);
+    CSP_CHKMPIFAIL_JUMP(mpi_errno);
+
+    if (local_remap_flag) {
+        int g_idx, u_idx, didx, i;
+        int domain_np, domain_num_g;
+
+        domain_np = local_nproc / topo_map.bind_ndomains;
+        domain_num_g = CSP_ENV.num_g / topo_map.bind_ndomains;
+
+        remap_ranks = (int *) CSP_calloc(local_nproc, sizeof(int));
+        domains_num_g_set = (int *) CSP_calloc(topo_map.ndomains, sizeof(int));
+
+        /* Reorder ranks: pick up the first domain_num_g units from each domain
+         * as ghosts, move them to the lowest ranks. */
+        g_idx = 0;
+        u_idx = domain_num_g * topo_map.bind_ndomains;
+        for (i = 0; i < local_nproc; i++) {
+            didx = topo_map.bind_infos[i].domain_idx;
+            if (domains_num_g_set[didx] < domain_num_g) {
+                remap_ranks[g_idx++] = i;
+                domains_num_g_set[didx]++;
+            }
+            else {
+                remap_ranks[u_idx++] = i;
+            }
+        }
+
+        CSP_ASSERT(g_idx == domain_num_g * topo_map.bind_ndomains);
+        CSP_ASSERT(u_idx == local_nproc);
+#ifdef TOPO_DEBUG
+        if (local_rank == 0) {
+            for (i = 0; i < local_nproc; i++)
+                printf("local remap_ranks[%d] %d\n", i, remap_ranks[i]);
+            fflush(stdout);
+        }
+#endif
+    }
+
+    /* Local remap on any node will cause a global remap. */
+    if (global_remap_flag) {
+        int wrank, wnproc;
+
+        CSP_CALLMPI(JUMP, PMPI_Comm_rank(MPI_COMM_WORLD, &wrank));
+        CSP_CALLMPI(JUMP, PMPI_Comm_size(MPI_COMM_WORLD, &wnproc));
+
+        world_remap_ranks = (int *) CSP_calloc(wnproc, sizeof(int));
+
+        if (local_remap_flag) {
+            /* Get the old world rank with my local offset if local remapped. */
+            CSP_CALLMPI(JUMP, PMPI_Group_translate_ranks(old_lgroup, 1,
+                                                         &remap_ranks[local_rank],
+                                                         CSP_PROC.wgroup,
+                                                         &world_remap_ranks[wrank]));
+        }
+        else {
+            world_remap_ranks[wrank] = wrank;
+        }
+
+        CSP_CALLMPI(JUMP, PMPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                                         world_remap_ranks, 1, MPI_INT, MPI_COMM_WORLD));
+
+        /* Create remapped comm_world and overwrite global group/comm. */
+        old_wgroup = CSP_PROC.wgroup;
+        CSP_CALLMPI(JUMP, PMPI_Group_incl(old_wgroup, wnproc, world_remap_ranks, &CSP_PROC.wgroup));
+        CSP_CALLMPI(JUMP, PMPI_Comm_create_group(MPI_COMM_WORLD, CSP_PROC.wgroup, 0,
+                                                 &CSP_PROC.wcomm));
+
+        CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.wcomm, &CSP_PROC.wrank));
+
+        /* Create remapped local comm and overwrite global group/comm. */
+        old_local_comm = CSP_PROC.local_comm;
+        CSP_CALLMPI(JUMP, PMPI_Comm_split_type(CSP_PROC.wcomm, MPI_COMM_TYPE_SHARED, 0,
+                                               MPI_INFO_NULL, &CSP_PROC.local_comm));
+
+        if (CSP_ENV.verbose & (int) CSP_MSG_INFO) {
+            topo_free_map(&topo_map);
+            topo_load_comm_map(CSP_ENV.topo.domain, CSP_PROC.local_comm, &topo_map);
+            if (wrank == 0)
+                CSP_msg_print(CSP_MSG_INFO, "TOPO: reordered\n");
+            CSP_CALLMPI(JUMP, PMPI_Barrier(CSP_PROC.wcomm));
+            topo_print_comm_map(topo_map);
+        }
+    }
+
+  fn_exit:
+    if (remap_ranks)
+        free(remap_ranks);
+    if (domains_num_g_set)
+        free(domains_num_g_set);
+    if (world_remap_ranks)
+        free(world_remap_ranks);
+    if (old_lgroup != MPI_GROUP_NULL)
+        CSP_CALLMPI_EXIT(PMPI_Group_free(&old_lgroup));
+    if (old_wgroup != MPI_GROUP_NULL)
+        CSP_CALLMPI_EXIT(PMPI_Group_free(&old_wgroup));
+    if (old_local_comm != MPI_COMM_NULL)
+        CSP_CALLMPI_EXIT(PMPI_Comm_free(&old_local_comm));
+
+    topo_free_map(&topo_map);
+
+    /* No topology work afterward */
+    topo_destroy();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/ghost/init/finalize.c
+++ b/src/ghost/init/finalize.c
@@ -53,8 +53,11 @@ static int destroy_proc(void)
         CSPG_DBG_PRINT(" free CSP_PROC.ghost.g_local_comm\n");
         CSP_CALLMPI(JUMP, PMPI_Comm_free(&CSP_PROC.ghost.g_local_comm));
     }
-
+    if (CSP_PROC.wcomm && CSP_PROC.wcomm != MPI_COMM_WORLD) {
+        CSP_CALLMPI(JUMP, PMPI_Comm_free(&CSP_PROC.wcomm));
+    }
     CSP_PROC.ghost.g_local_comm = MPI_COMM_NULL;
+    CSP_PROC.wcomm = MPI_COMM_NULL;
 
   fn_exit:
     return mpi_errno;

--- a/src/ghost/init/init.c
+++ b/src/ghost/init/init.c
@@ -18,8 +18,8 @@ static int dbg_print_proc(void)
 
     CSP_ASSERT(CSP_IS_GHOST);
 
-    CSP_CALLMPI(RETURN, PMPI_Comm_size(MPI_COMM_WORLD, &nprocs));
-    CSP_CALLMPI(RETURN, PMPI_Comm_rank(MPI_COMM_WORLD, &rank));
+    CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_PROC.wcomm, &nprocs));
+    CSP_CALLMPI(RETURN, PMPI_Comm_rank(CSP_PROC.wcomm, &rank));
     CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_PROC.local_comm, &local_nprocs));
     CSP_CALLMPI(RETURN, PMPI_Comm_rank(CSP_PROC.local_comm, &local_rank));
     CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_PROC.ghost.g_local_comm, &local_ghost_nprocs));
@@ -65,6 +65,8 @@ int CSPG_global_init(void)
 
     /* Disable MPI automatic error messages. */
     CSP_CALLMPI(JUMP, PMPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN));
+    if (CSP_PROC.wcomm != MPI_COMM_WORLD)
+        CSP_CALLMPI(JUMP, PMPI_Comm_set_errhandler(CSP_PROC.wcomm, MPI_ERRORS_RETURN));
 
   fn_exit:
     return mpi_errno;

--- a/src/ghost/rma/win_allocate.c
+++ b/src/ghost/rma/win_allocate.c
@@ -76,7 +76,7 @@ static int create_ug_comm(int user_nprocs, int *user_ranks_in_world, int num_gho
     MPI_Group ug_group = MPI_GROUP_NULL;
     int num_ug_ranks;
 
-    CSP_CALLMPI(JUMP, PMPI_Comm_size(MPI_COMM_WORLD, &world_nprocs));
+    CSP_CALLMPI(JUMP, PMPI_Comm_size(CSP_PROC.wcomm, &world_nprocs));
 
     /* maximum amount equals to world size */
     ug_ranks_in_world = CSP_calloc(world_nprocs, sizeof(int));
@@ -99,7 +99,7 @@ static int create_ug_comm(int user_nprocs, int *user_ranks_in_world, int num_gho
 
     /* -Create ug communicator. */
     CSP_CALLMPI(JUMP, PMPI_Group_incl(CSP_PROC.wgroup, num_ug_ranks, ug_ranks_in_world, &ug_group));
-    CSP_CALLMPI(JUMP, PMPI_Comm_create_group(MPI_COMM_WORLD, ug_group, 0, &win->ug_comm));
+    CSP_CALLMPI(JUMP, PMPI_Comm_create_group(CSP_PROC.wcomm, ug_group, 0, &win->ug_comm));
 
   fn_exit:
     if (ug_ranks_in_world)
@@ -128,7 +128,7 @@ static int create_communicators(CSPG_win_t * win)
          *  ug_comm: including all USER and Ghost processes
          */
         win->local_ug_comm = CSP_PROC.local_comm;
-        win->ug_comm = MPI_COMM_WORLD;
+        win->ug_comm = CSP_PROC.wcomm;
     }
     else {
         /* Receive parameters from local user root

--- a/src/ghost/rma/win_free.c
+++ b/src/ghost/rma/win_free.c
@@ -68,7 +68,7 @@ static int win_free_impl(CSP_cwp_fnc_winfree_pkt_t * winfree_pkt)
             CSP_CALLMPI(JUMP, PMPI_Comm_free(&win->local_ug_comm));
         }
 
-        if (win->ug_comm && win->ug_comm != MPI_COMM_WORLD) {
+        if (win->ug_comm && win->ug_comm != CSP_PROC.wcomm) {
             CSPG_DBG_PRINT(" free ug communicator\n");
             CSP_CALLMPI(JUMP, PMPI_Comm_free(&win->ug_comm));
         }

--- a/src/user/init/finalize.c
+++ b/src/user/init/finalize.c
@@ -32,6 +32,10 @@ static int destroy_proc(void)
     if (CSP_PROC.wgroup && CSP_PROC.wgroup != MPI_GROUP_NULL) {
         CSP_CALLMPI(JUMP, PMPI_Group_free(&CSP_PROC.wgroup));
     }
+    if (CSP_PROC.wcomm != MPI_COMM_WORLD && CSP_PROC.wcomm != MPI_COMM_NULL) {
+        CSP_DBG_PRINT(" free CSP_PROC.wcomm\n");
+        CSP_CALLMPI(JUMP, PMPI_Comm_free(&CSP_PROC.wcomm));
+    }
 
     CSP_PROC.local_comm = MPI_COMM_NULL;
     CSP_PROC.wgroup = MPI_GROUP_NULL;
@@ -80,6 +84,8 @@ static int destroy_proc(void)
 static void comm_errhan_cleanup_predefined(void)
 {
     CSPU_comm_errhan_reset(MPI_COMM_WORLD);
+    if (CSP_PROC.wcomm != MPI_COMM_WORLD)
+        CSPU_comm_errhan_reset(CSP_PROC.wcomm);
     CSPU_comm_errhan_reset(CSP_COMM_USER_WORLD);
     CSPU_comm_errhan_reset(MPI_COMM_SELF);
 }

--- a/src/user/init/init.c
+++ b/src/user/init/init.c
@@ -19,8 +19,8 @@ static int dbg_print_proc(void)
 
     CSP_ASSERT(CSP_IS_USER);
 
-    CSP_CALLMPI(RETURN, PMPI_Comm_size(MPI_COMM_WORLD, &nprocs));
-    CSP_CALLMPI(RETURN, PMPI_Comm_rank(MPI_COMM_WORLD, &rank));
+    CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_PROC.wcomm, &nprocs));
+    CSP_CALLMPI(RETURN, PMPI_Comm_rank(CSP_PROC.wcomm, &rank));
     CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_PROC.local_comm, &local_nprocs));
     CSP_CALLMPI(RETURN, PMPI_Comm_rank(CSP_PROC.local_comm, &local_rank));
     CSP_CALLMPI(RETURN, PMPI_Comm_size(CSP_COMM_USER_WORLD, &user_nprocs));
@@ -150,6 +150,11 @@ static int comm_errhan_wrap_predefined(void)
      * and the errors happened in CASPER overwriting calls (RETURN). */
     mpi_errno = CSPU_comm_errhan_wrap(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL, NULL);
     CSP_CHKMPIFAIL_JUMP(mpi_errno);
+
+    if (CSP_PROC.wcomm != MPI_COMM_WORLD) {
+        mpi_errno = CSPU_comm_errhan_wrap(CSP_PROC.wcomm, MPI_ERRORS_ARE_FATAL, NULL);
+        CSP_CHKMPIFAIL_JUMP(mpi_errno);
+    }
 
     mpi_errno = CSPU_comm_errhan_wrap(CSP_COMM_USER_WORLD, MPI_ERRORS_ARE_FATAL, NULL);
     CSP_CHKMPIFAIL_JUMP(mpi_errno);

--- a/src/user/rma/win_allocate.c
+++ b/src/user/rma/win_allocate.c
@@ -264,7 +264,7 @@ static int gather_ranks(CSPU_win_t * win, int *num_ghosts, int *gp_ranks_in_worl
     int i, j, gp_rank;
     int world_nprocs;
 
-    CSP_CALLMPI(JUMP, PMPI_Comm_size(MPI_COMM_WORLD, &world_nprocs));
+    CSP_CALLMPI(JUMP, PMPI_Comm_size(CSP_PROC.wcomm, &world_nprocs));
     CSP_CALLMPI(JUMP, PMPI_Comm_size(win->user_comm, &user_nprocs));
 
     gp_bitmap = CSP_calloc(world_nprocs, sizeof(int));
@@ -315,7 +315,7 @@ static int create_ug_comm(int num_ghosts, int *gp_ranks_in_world, CSPU_win_t * w
 
     CSP_CALLMPI(JUMP, PMPI_Comm_size(win->user_comm, &user_nprocs));
     CSP_CALLMPI(JUMP, PMPI_Comm_rank(win->user_comm, &user_rank));
-    CSP_CALLMPI(JUMP, PMPI_Comm_size(MPI_COMM_WORLD, &world_nprocs));
+    CSP_CALLMPI(JUMP, PMPI_Comm_size(CSP_PROC.wcomm, &world_nprocs));
 
     /* maximum amount equals to world size */
     ug_ranks_in_world = CSP_calloc(world_nprocs, sizeof(int));
@@ -333,7 +333,7 @@ static int create_ug_comm(int num_ghosts, int *gp_ranks_in_world, CSPU_win_t * w
 
     CSP_CALLMPI(JUMP, PMPI_Group_incl(CSP_PROC.wgroup, num_ug_ranks,
                                       ug_ranks_in_world, &win->ug_group));
-    CSP_CALLMPI(JUMP, PMPI_Comm_create_group(MPI_COMM_WORLD, win->ug_group, 0, &win->ug_comm));
+    CSP_CALLMPI(JUMP, PMPI_Comm_create_group(CSP_PROC.wcomm, win->ug_group, 0, &win->ug_comm));
 
   fn_exit:
     if (ug_ranks_in_world)
@@ -379,7 +379,7 @@ static int create_communicators(CSPU_win_t * ug_win)
          *  ug_comm: including all USER and Ghost processes
          */
         ug_win->local_ug_comm = CSP_PROC.local_comm;
-        ug_win->ug_comm = MPI_COMM_WORLD;
+        ug_win->ug_comm = CSP_PROC.wcomm;
         CSP_CALLMPI(JUMP, PMPI_Comm_group(ug_win->local_ug_comm, &ug_win->local_ug_group));
         CSP_CALLMPI(JUMP, PMPI_Comm_group(ug_win->ug_comm, &ug_win->ug_group));
 
@@ -756,7 +756,7 @@ int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info,
     CSP_CALLMPI(JUMP, PMPI_Comm_rank(user_comm, &user_rank));
     CSP_CALLMPI(JUMP, PMPI_Comm_size(ug_win->local_user_comm, &user_local_nprocs));
     CSP_CALLMPI(JUMP, PMPI_Comm_rank(ug_win->local_user_comm, &user_local_rank));
-    CSP_CALLMPI(JUMP, PMPI_Comm_rank(MPI_COMM_WORLD, &world_rank));
+    CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_PROC.wcomm, &world_rank));
     CSP_CALLMPI(JUMP, PMPI_Comm_rank(CSP_COMM_USER_WORLD, &user_world_rank));
 
     ug_win->g_ranks_in_ug = CSP_calloc(CSP_ENV.num_g * ug_win->num_nodes, sizeof(MPI_Aint));

--- a/src/user/rma/win_free.c
+++ b/src/user/rma/win_free.c
@@ -68,7 +68,7 @@ int CSPU_win_release(CSPU_win_t * ug_win)
         CSP_CALLMPI(JUMP, PMPI_Comm_free(&ug_win->local_ug_comm));
     }
 
-    if (ug_win->ug_comm && ug_win->ug_comm != MPI_COMM_NULL && ug_win->ug_comm != MPI_COMM_WORLD) {
+    if (ug_win->ug_comm && ug_win->ug_comm != MPI_COMM_NULL && ug_win->ug_comm != CSP_PROC.wcomm) {
         CSP_DBG_PRINT("\t free ug communicator\n");
         CSP_CALLMPI(JUMP, PMPI_Comm_free(&ug_win->ug_comm));
     }

--- a/test/comm_errhan.c
+++ b/test/comm_errhan.c
@@ -91,8 +91,8 @@ static void comm_errhan_fnc(MPI_Comm * errcomm, int *err, ...)
 
     if (*errcomm != exp_comm) {
         errs++;
-        err_printf("In %s: unexpected communicator (got %x expected %x)\n",
-                   __FUNCTION__, (int) *errcomm, (int) exp_comm);
+        err_printf("In %s: unexpected communicator (got %lx expected %lx)\n",
+                   __FUNCTION__, (unsigned long) *errcomm, (unsigned long) exp_comm);
     }
     comm_errhan_ncalls++;
     debug_printf("%s called, comm_errhan_ncalls=%d, exp_comm_errhan_ncalls=%d\n",

--- a/test/runtest.in
+++ b/test/runtest.in
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 
 path=$(pwd)
+mpicc=@CC@
+abs_top_srcdir=@abs_top_srcdir@
 
 ##########################################################
 # test configuration with default value
@@ -90,6 +92,53 @@ if [ "x$JUNIT" != "x" ]; then
     JUNIT_ENABLED=1
     JUNIT_OUTPUT="$JUNIT"
     echo "" > $JUNIT_OUTPUT
+fi
+
+##########################################################
+# detect MPI type (ompi|mpich|impi) and read xfails file
+
+mpi_type=mpich
+mpicc_base=$(basename $mpicc)
+tmp_mpidir=$(which $mpicc 2>/dev/null)
+mpidir=`echo $tmp_mpidir| sed -e 's_/[^/]*$__g'`/../
+if [ -d $mpidir ] && [ -f $mpidir/bin/ompi_info ]; then
+    mpi_type=ompi
+elif [ -d $mpidir ] && [ -f $mpidir/bin/mpichversion ]; then
+    mpi_type=mpich
+elif [ "$mpicc_base" = "mpiicc" ]; then
+    mpi_type=impi
+fi
+
+xfailf="$abs_top_srcdir/xfail.$mpi_type"
+num_xfails=0
+xfail_programs=
+xfail_nps=
+xfail_ngs=
+
+# ignore xfail file if does not exist
+if [ -f $xfailf ]; then
+    echo "Parsing $xfailf"
+    first=1
+    while read LINE
+    do
+        #skip the first commend line
+        if [ $first -eq 1 ];then
+            first=0
+            continue
+        fi
+
+        # parse format: program np ng
+        f=$(echo "$LINE"|awk '{print $1}')
+        np=$(echo "$LINE"|awk '{print $2}')
+        ng=$(echo "$LINE"|awk '{print $3}')
+
+        if [ -f $path/$f ];then
+            xfail_programs[$num_xfails]=$f
+            xfail_nps[$num_xfails]=$np
+            xfail_ngs[$num_xfails]=$ng
+            let num_xfails+=1
+        fi
+    done < $xfailf
 fi
 
 ##########################################################
@@ -226,6 +275,34 @@ EOF
     rm -f $JUNIT_TEMP_OUTPUT
 }
 
+# - check xfail for a test program 
+#   check_xfail <testfile> <np> <CSP_NG>
+function check_xfail()
+{
+    fpath=$1
+    np=$2
+    ng=$3
+    f=$(basename $fpath)
+
+    xi=0
+    while [ $xi -lt $num_xfails ]
+    do
+        xfail_prog=${xfail_programs[$xi]}
+        xfail_np=${xfail_nps[$xi]}
+        xfail_ng=${xfail_ngs[$xi]}
+
+        if [ "$f" = "$xfail_prog" ] ; then
+            if [ "$np" = "$xfail_np" ] ||  [ "*" = "$xfail_np" ]; then
+                if [ "$ng" = "$xfail_ng" ] ||  [ "*" = "$xfail_ng" ]; then
+                    echo "1"
+                    return
+                fi
+            fi
+        fi
+        let xi+=1
+    done
+    echo "0"
+}
 
 # - execute a test program
 #   exec_program <mpiexec> <relative path of testfile>
@@ -257,6 +334,7 @@ function exec_program()
 function exec_all_programs()
 {
     mpiexec=$1
+    np=$2
 
     if [ "x$CSP_NG" = "x" ] || [ "$CSP_NG" -lt "0" ];then
         echo "invalid CSP_NG=$CSP_NG !"
@@ -268,12 +346,14 @@ function exec_all_programs()
     do
         f=${programs[$i]}
         exec=${exec_flags[$i]}
+        xfail=$(check_xfail $f $np $CSP_NG)
 
-        if [ "$exec" -eq "0" ]; then
-            echo "skip test $f"
+        if [ "$exec" -eq "0" ] || [ "$xfail" -eq "1" ]; then
+            echo "skip test $f -np $np CSP_NG=$CSP_NG"
+            echo ""
 
             # junit_report_testcase <exec> <result:0:pass | 1:failed | 2:skipped> <output>
-            junit_report_testcase "$mpiexec $f" "2"
+            junit_report_testcase "CSP_NG=$CSP_NG; $mpiexec $f" "2"
 
             let i+=1
             continue
@@ -304,7 +384,7 @@ if [ "$test_mode" = "a" ];then
         fi
         for ng in 0 1; do
             export CSP_NG=$ng
-            exec_all_programs "$test_mpiexec $np"
+            exec_all_programs "$test_mpiexec $np" $np
         done
     done
 
@@ -313,7 +393,7 @@ if [ "$test_mode" = "a" ];then
             break #skip larger np
         fi
         export CSP_NG=2
-        exec_all_programs "$test_mpiexec $np"
+        exec_all_programs "$test_mpiexec $np" $np
     done
 else
     # User provides MPIEXEC, NP (or default 4) and NG (or default 1)
@@ -324,7 +404,7 @@ else
     echo ""
 
     export CSP_NG=$test_ng
-    exec_all_programs "$test_mpiexec $test_np"
+    exec_all_programs "$test_mpiexec $test_np" $test_np
 fi
 
 junit_report_finish

--- a/test/win_errhan.c
+++ b/test/win_errhan.c
@@ -83,8 +83,8 @@ static void win_errhan_fnc(MPI_Win * errwin, int *err, ...)
 
     if (*errwin != win) {
         errs++;
-        err_printf("In %s: unexpected window (got %x expected %x)\n",
-                   __FUNCTION__, (int) *errwin, (int) win);
+        err_printf("In %s: unexpected window (got %lx expected %lx)\n",
+                   __FUNCTION__, (unsigned long) *errwin, (unsigned long) win);
     }
     win_errhan_ncalls++;
 }

--- a/test/xfail.ompi
+++ b/test/xfail.ompi
@@ -1,0 +1,2 @@
+#<test> <np> <ng>
+win_errhan * 0

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -38,7 +38,22 @@ esac
 make V=1
 make V=1 install
 
+# Set test configuration
 export CSP_VERBOSE="err|conf_g|info"
 export MPIEXEC_TIMEOUT=600 # in seconds
+
+TEST_MPIEXEC=
+case "$MPI_IMPL" in
+    mpich)
+        TEST_MPIEXEC="mpiexec -np"
+        ;;
+    openmpi)
+        # --oversubscribe fixes error "Either request fewer slots for your 
+        # application, or make more slots available for use." on osx.
+        # see https://github.com/open-mpi/ompi/issues/3133
+        TEST_MPIEXEC="mpiexec --oversubscribe -np"
+        ;;
+esac
+
 # Run unit tests
-make V=1 check MAX_NP=5
+make V=1 check MPIEXEC="$TEST_MPIEXEC" MAX_NP=5

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -38,7 +38,7 @@ esac
 make V=1
 make V=1 install
 
-export CSP_VERBOSE=1
+export CSP_VERBOSE="err|conf_g|info"
 export MPIEXEC_TIMEOUT=600 # in seconds
 # Run unit tests
 make V=1 check MAX_NP=5

--- a/travis/install-autotools.sh
+++ b/travis/install-autotools.sh
@@ -6,119 +6,106 @@ set -x
 os=`uname`
 TOP="$1"
 
-case "$os" in
-    Darwin)
-        brew update
-        brew info autoconf automake libtool
-        brew install autoconf automake libtool | brew upgrade autoconf automake libtool | true
-        which glibtool
-        which glibtoolize
-        glibtool --version
-        mkdir -p ${TOP}/bin
-        ln -s `which glibtool` ${TOP}/bin/libtool
-        ln -s `which glibtoolize` ${TOP}/bin/libtoolize
-        ;;
-    Linux)
-        MAKE_JNUM=2
-        M4_VERSION=1.4.17
-        LIBTOOL_VERSION=2.4.6
-        AUTOCONF_VERSION=2.69
-        AUTOMAKE_VERSION=1.15
+      MAKE_JNUM=2
+      M4_VERSION=1.4.17
+      LIBTOOL_VERSION=2.4.6
+      AUTOCONF_VERSION=2.69
+      AUTOMAKE_VERSION=1.15
 
-        cd ${TOP}
-        TOOL=m4
-        TDIR=${TOOL}-${M4_VERSION}
-        FILE=${TDIR}.tar.gz
-        BIN=${TOP}/bin/${TOOL}
-        if [ -f ${FILE} ] ; then
-          echo ${FILE} already exists! Using existing copy.
-        else
-          wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
+      cd ${TOP}
+      TOOL=m4
+      TDIR=${TOOL}-${M4_VERSION}
+      FILE=${TDIR}.tar.gz
+      BIN=${TOP}/bin/${TOOL}
+      if [ -f ${FILE} ] ; then
+        echo ${FILE} already exists! Using existing copy.
+      else
+        wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
+      fi
+      if [ -d ${TDIR} ] ; then
+        echo ${TDIR} already exists! Using existing copy.
+      else
+        echo Unpacking ${FILE}
+        tar -xzf ${FILE}
+      fi
+      if [ -f ${BIN} ] ; then
+        echo ${BIN} already exists! Skipping build.
+      else
+        cd ${TOP}/${TDIR}
+        ./configure --prefix=${TOP} && make -j ${MAKE_JNUM} && make install
+        if [ "x$?" != "x0" ] ; then
+          echo FAILURE 1
+          exit
         fi
-        if [ -d ${TDIR} ] ; then
-          echo ${TDIR} already exists! Using existing copy.
-        else
-          echo Unpacking ${FILE}
-          tar -xzf ${FILE}
-        fi
-        if [ -f ${BIN} ] ; then
-          echo ${BIN} already exists! Skipping build.
-        else
-          cd ${TOP}/${TDIR}
-          ./configure --prefix=${TOP} && make -j ${MAKE_JNUM} && make install
-          if [ "x$?" != "x0" ] ; then
-            echo FAILURE 1
-            exit
-          fi
-        fi
+      fi
 
-        cd ${TOP}
-        TOOL=libtool
-        TDIR=${TOOL}-${LIBTOOL_VERSION}
-        FILE=${TDIR}.tar.gz
-        BIN=${TOP}/bin/${TOOL}
-        if [ ! -f ${FILE} ] ; then
-          wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
-        else
-          echo ${FILE} already exists! Using existing copy.
+      cd ${TOP}
+      TOOL=libtool
+      TDIR=${TOOL}-${LIBTOOL_VERSION}
+      FILE=${TDIR}.tar.gz
+      BIN=${TOP}/bin/${TOOL}
+      if [ ! -f ${FILE} ] ; then
+        wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
+      else
+        echo ${FILE} already exists! Using existing copy.
+      fi
+      if [ ! -d ${TDIR} ] ; then
+        echo Unpacking ${FILE}
+        tar -xzf ${FILE}
+      else
+        echo ${TDIR} already exists! Using existing copy.
+      fi
+      if [ -f ${BIN} ] ; then
+        echo ${BIN} already exists! Skipping build.
+      else
+        cd ${TOP}/${TDIR}
+        ./configure --prefix=${TOP} M4=${TOP}/bin/m4 && make -j ${MAKE_JNUM} && make install
+        if [ "x$?" != "x0" ] ; then
+          echo FAILURE 2
+          exit
         fi
-        if [ ! -d ${TDIR} ] ; then
-          echo Unpacking ${FILE}
-          tar -xzf ${FILE}
-        else
-          echo ${TDIR} already exists! Using existing copy.
-        fi
-        if [ -f ${BIN} ] ; then
-          echo ${BIN} already exists! Skipping build.
-        else
-          cd ${TOP}/${TDIR}
-          ./configure --prefix=${TOP} M4=${TOP}/bin/m4 && make -j ${MAKE_JNUM} && make install
-          if [ "x$?" != "x0" ] ; then
-            echo FAILURE 2
-            exit
-          fi
-        fi
+      fi
 
-        cd ${TOP}
-        TOOL=autoconf
-        TDIR=${TOOL}-${AUTOCONF_VERSION}
-        FILE=${TDIR}.tar.gz
-        BIN=${TOP}/bin/${TOOL}
-        if [ ! -f ${FILE} ] ; then
-          wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
-        else
-          echo ${FILE} already exists! Using existing copy.
+      cd ${TOP}
+      TOOL=autoconf
+      TDIR=${TOOL}-${AUTOCONF_VERSION}
+      FILE=${TDIR}.tar.gz
+      BIN=${TOP}/bin/${TOOL}
+      if [ ! -f ${FILE} ] ; then
+        wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
+      else
+        echo ${FILE} already exists! Using existing copy.
+      fi
+      if [ ! -d ${TDIR} ] ; then
+        echo Unpacking ${FILE}
+        tar -xzf ${FILE}
+      else
+        echo ${TDIR} already exists! Using existing copy.
+      fi
+      if [ -f ${BIN} ] ; then
+        echo ${BIN} already exists! Skipping build.
+      else
+        cd ${TOP}/${TDIR}
+        ./configure --prefix=${TOP} M4=${TOP}/bin/m4 && make -j ${MAKE_JNUM} && make install
+        if [ "x$?" != "x0" ] ; then
+          echo FAILURE 3
+          exit
         fi
-        if [ ! -d ${TDIR} ] ; then
-          echo Unpacking ${FILE}
-          tar -xzf ${FILE}
-        else
-          echo ${TDIR} already exists! Using existing copy.
-        fi
-        if [ -f ${BIN} ] ; then
-          echo ${BIN} already exists! Skipping build.
-        else
-          cd ${TOP}/${TDIR}
-          ./configure --prefix=${TOP} M4=${TOP}/bin/m4 && make -j ${MAKE_JNUM} && make install
-          if [ "x$?" != "x0" ] ; then
-            echo FAILURE 3
-            exit
-          fi
-        fi
+      fi
 
-        cd ${TOP}
-        TOOL=automake
-        TDIR=${TOOL}-${AUTOMAKE_VERSION}
-        FILE=${TDIR}.tar.gz
-        BIN=${TOP}/bin/${TOOL}
-        if [ ! -f ${FILE} ] ; then
-          wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
-        else
-          echo ${FILE} already exists! Using existing copy.
-        fi
-        if [ ! -d ${TDIR} ] ; then
-          echo Unpacking ${FILE}
-          tar -xzf ${FILE}
+      cd ${TOP}
+      TOOL=automake
+      TDIR=${TOOL}-${AUTOMAKE_VERSION}
+      FILE=${TDIR}.tar.gz
+      BIN=${TOP}/bin/${TOOL}
+      if [ ! -f ${FILE} ] ; then
+        wget http://ftp.gnu.org/gnu/${TOOL}/${FILE}
+      else
+        echo ${FILE} already exists! Using existing copy.
+      fi
+      if [ ! -d ${TDIR} ] ; then
+        echo Unpacking ${FILE}
+        tar -xzf ${FILE}
         else
           echo ${TDIR} already exists! Using existing copy.
         fi
@@ -132,6 +119,4 @@ case "$os" in
             exit
           fi
         fi
-        ;;
-esac
 

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -37,9 +37,10 @@ case "$os" in
         case "$MPI_IMPL" in
             mpich)
                 if [ ! -d "$TRAVIS_ROOT/mpich" ]; then
-                    wget --no-check-certificate http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
-                    tar -xzf mpich-3.2.tar.gz
-                    cd mpich-3.2
+                    # mpich-v3.3a2 has symbol visibility issue, see https://github.com/pmodels/mpich/issues/2471.
+                    wget --no-check-certificate http://www.mpich.org/static/downloads/nightly/master/mpich/mpich-master-v3.3a2-452-ge0000be3f049.tar.gz
+                    tar -xzf mpich-master-v3.3a2-452-ge0000be3f049.tar.gz
+                    cd mpich-master-v3.3a2-452-ge0000be3f049
                     mkdir build && cd build
                     ../configure CFLAGS="-w" --prefix=$TRAVIS_ROOT/mpich --disable-fortran --disable-static
                     make -j2

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -50,9 +50,9 @@ case "$os" in
                 ;;
             openmpi)
                 if [ ! -d "$TRAVIS_ROOT/open-mpi" ]; then
-                    wget --no-check-certificate https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.bz2
-                    tar -xjf openmpi-2.0.2.tar.bz2
-                    cd openmpi-2.0.2
+                    wget --no-check-certificate https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2
+                    tar -xjf openmpi-3.0.0.tar.bz2
+                    cd openmpi-3.0.0
                     mkdir build && cd build
                     ../configure CFLAGS="-w" --prefix=$TRAVIS_ROOT/open-mpi \
                                 --without-verbs --without-fca --without-mxm --without-ucx \


### PR DESCRIPTION
It checks whether user set core binding and reorders ranks at MPI
initialization to ensure ghosts are distributed to all domains. It is
user's responsibility to ensure even core binding, Casper does not
change or set core binding.

Example: if binds cross two sockets with 2 ghosts: 0123 4567,
0 and 4 are chosen as the ghost for 123 and 456, respectively.

Set CSP_VERBOSE=info to print topology information.