### PR TITLE
fix build issues related to Open-MPI function deletion

### DIFF
--- a/src/user/errhan/errhandler_create.c
+++ b/src/user/errhan/errhandler_create.c
@@ -9,9 +9,13 @@
 #include <stdlib.h>
 #include <mpi.h>
 
+#ifndef OMPI_OMIT_MPI1_COMPAT_DECLS
+
 int MPI_Errhandler_create(MPI_Handler_function * errhandler_fn, MPI_Errhandler * errhandler)
 {
     /* Deprecated function, replaced by MPI_Comm_create_errhandler.
      * See overwritten content in MPI_Comm_create_errhandler. */
     return MPI_Comm_create_errhandler((MPI_Comm_errhandler_function *) errhandler_fn, errhandler);
 }
+
+#endif /* OMPI_OMIT_MPI1_COMPAT_DECLS */

--- a/src/user/errhan/errhandler_free.c
+++ b/src/user/errhan/errhandler_free.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include "cspu.h"
 
+#ifndef OMPI_OMIT_MPI1_COMPAT_DECLS
+
 int MPI_Errhandler_free(MPI_Errhandler * errhandler)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -27,3 +29,5 @@ int MPI_Errhandler_free(MPI_Errhandler * errhandler)
   fn_fail:
     goto fn_exit;
 }
+
+#endif /* OMPI_OMIT_MPI1_COMPAT_DECLS */

--- a/src/user/errhan/errhandler_get.c
+++ b/src/user/errhan/errhandler_get.c
@@ -7,9 +7,13 @@
 #include <stdlib.h>
 #include <mpi.h>
 
+#ifndef OMPI_OMIT_MPI1_COMPAT_DECLS
+
 int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler * errhandler)
 {
     /* Deprecated function, replaced by MPI_Comm_get_errhandler.
      * See overwritten content in MPI_Comm_get_errhandler. */
     return MPI_Comm_get_errhandler(comm, errhandler);
 }
+
+#endif /* OMPI_OMIT_MPI1_COMPAT_DECLS */

--- a/src/user/errhan/errhandler_set.c
+++ b/src/user/errhan/errhandler_set.c
@@ -8,9 +8,13 @@
 #include <stdlib.h>
 #include <mpi.h>
 
+#ifndef OMPI_OMIT_MPI1_COMPAT_DECLS
+
 int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
 {
     /* Deprecated function, replaced by MPI_Comm_set_errhandler.
      * See overwritten content in MPI_Comm_set_errhandler. */
     return MPI_Comm_set_errhandler(comm, errhandler);
 }
+
+#endif /* OMPI_OMIT_MPI1_COMPAT_DECLS */


### PR DESCRIPTION
Open-MPI implemented the deletion of MPI_Errhandler_* functions,
including helpful notification that causes the build to fail.
This change disables the missing functions.

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>

Resolves https://github.com/pmodels/casper/issues/36