### PR TITLE
Allow non-contiguous option for MPI_Win_allocate

### DIFF
--- a/src/ghost/rma/win_allocate.c
+++ b/src/ghost/rma/win_allocate.c
@@ -222,7 +222,7 @@ static int alloc_shared_window(MPI_Info user_info, MPI_Aint * size, CSPG_win_t *
         CSP_CALLMPI(JUMP, PMPI_Info_dup(user_info, &shared_info));
         CSP_CALLMPI(JUMP, PMPI_Info_set(shared_info, "alloc_shm", "true"));
         CSP_CALLMPI(JUMP, PMPI_Info_set(shared_info, "same_size", "false"));
-        CSP_CALLMPI(JUMP, PMPI_Info_set(shared_info, "alloc_shared_noncontig", "false"));
+        //CSP_CALLMPI(JUMP, PMPI_Info_set(shared_info, "alloc_shared_noncontig", "false"));
     }
 
     /* -Allocate shared window in CHAR type


### PR DESCRIPTION
This is a draft PR, work in progress to address known Issues #2 in README:

**alloc_shared_noncontig** option is forced to be true for shared window at the moment, to enable non-contiguous memory some additional operations/functionalities would be necessary.

Most obviously, the offset from target user to ghost base needs to be recalculated. Aside from the existing approach (of accumulating window sizes of all ghosts+users in front of calling process), I'm adding a new calculation, using MPI_shared_query from ghost processes to query users' base address (local to ghost) in shared window, then send <code>offset = usr_addr-ghost_base</code> back to users in middle of<code> alloc_shared_window</code> function.

But the subsequent window creation and RMA wrapper will be further complicated, too. Few months ago when I was first looking at this issue, I recall there were some difficulties when I was looking at <code>CSPU_target_get_ghost</code> protocols, as well as some critical conflicts with Window flavor requirement. I can't remember the specific details (which is problematic) and have to start over to review the code. 

For this reason this draft PR will also serve as a personal log, lest I forget my previous efforts wherever I left them due to my unpredictable schedule :S
